### PR TITLE
lm-format-enforcer 0.10.12

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-channels:
-  - https://staging.continuum.io/pbp/fs/interegular-feedstock/pr2/6100888

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+  - https://staging.continuum.io/pbp/fs/interegular-feedstock/pr2/6100888

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "lm-format-enforcer" %}
-{% set version = "0.10.9" %}
+{% set version = "0.10.12" %}
 
 package:
   name: {{ name|lower }}
@@ -7,20 +7,20 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/lm_format_enforcer-{{ version }}.tar.gz
-  sha256: 3e0bfeaf9fac9f69c8947da554db9a19a76d0be6e85075055f2c70d0aca420da
+  sha256: 130bd7ce8a6b224f25b6314ba9ae78ee4b48594db1767c74391c9182e2902a6c
 
 build:
-  noarch: python
+  skip: true # [ py<310 ]
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   number: 1
 
 requirements:
   host:
-    - python {{ python_min }}
+    - python
     - poetry-core >=1.1.0
     - pip
   run:
-    - python >={{ python_min }},<4.0
+    - python
     - pydantic >=1.10.8
     - interegular >=0.3.2
     - packaging
@@ -34,14 +34,26 @@ test:
   requires:
     - pip
     - numpy >=1.21.0
-    - python {{ python_min }}
+    - python
 
 about:
   home: https://github.com/noamgat/lm-format-enforcer
   summary: Enforce the output format (JSON Schema, Regex etc) of a language model
+  description: |
+    Language models are able to generate text, but when requiring a precise
+    output format, they do not always perform as instructed. Various prompt
+    engineering techniques have been introduced to improve the robustness of
+    the generated text, but they are not always sufficient. This project solves
+    the issues by filtering the tokens that the language model is allowed to
+    generate at every timestep, thus ensuring that the output format is
+    respected, while minimizing the limitations on the language model.
   license: MIT
   license_file: LICENSE
+  doc_url: https://github.com/noamgat/lm-format-enforcer
+  dev_url: https://github.com/noamgat/lm-format-enforcer
 
 extra:
+  recipe-maintainers:
+    - ianaobi
   recipe-maintainers:
     - rxm7706


### PR DESCRIPTION
lm-format-enforcer 0.10.12

**Destination channel:** defaults

Note: Not yet pinned in aggregate

### Links

- Jira ticket: [PKG-11459](https://anaconda.atlassian.net/browse/PKG-11459) 
- upstream repo: https://github.com/noamgat/lm-format-enforcer
- upstream release notes: https://github.com/noamgat/lm-format-enforcer/releases
- conda-forge repo: https://github.com/conda-forge/lm-format-enforcer-feedstock

### Explanation of changes:

- New recipe on the main channel. The whole recipe should be reviewed, though it is slightly based off of the conda-forge recipe.
- Part of vllm dependency chain


[PKG-11459]: https://anaconda.atlassian.net/browse/PKG-11459?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ