### PR TITLE
lm-format-enforcer 0.11.3

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -48,6 +48,7 @@ about:
     generate at every timestep, thus ensuring that the output format is
     respected, while minimizing the limitations on the language model.
   license: MIT
+  license_family: MIT
   license_file: LICENSE
   doc_url: https://github.com/noamgat/lm-format-enforcer
   dev_url: https://github.com/noamgat/lm-format-enforcer

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "lm-format-enforcer" %}
-{% set version = "0.10.12" %}
+{% set version = "0.11.3" %}
 
 package:
   name: {{ name|lower }}
@@ -7,12 +7,12 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/lm_format_enforcer-{{ version }}.tar.gz
-  sha256: 130bd7ce8a6b224f25b6314ba9ae78ee4b48594db1767c74391c9182e2902a6c
+  sha256: e68081c108719cce284a9bcc889709b26ffb085a1945b5eba3a12cfa96d528da
 
 build:
   skip: true # [ py<310 ]
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  number: 1
+  number: 0
 
 requirements:
   host:
@@ -55,5 +55,4 @@ about:
 extra:
   recipe-maintainers:
     - ianaobi
-  recipe-maintainers:
     - rxm7706


### PR DESCRIPTION
lm-format-enforcer 0.11.3

**Destination channel:** defaults

### Links

- [PKG-14792](https://anaconda.atlassian.net/browse/PKG-14792)
- Upstream repository: https://github.com/noamgat/lm-format-enforcer
- Upstream tag: https://github.com/noamgat/lm-format-enforcer/releases/tag/v0.11.3
- Diff: https://github.com/noamgat/lm-format-enforcer/compare/v0.10.12...v0.11.3
- Parent ticket: [PKG-13217](https://anaconda.atlassian.net/browse/PKG-13217) (vllm latest)

### Explanation of changes:

- Version bump 0.10.12 → 0.11.3; sha256 refreshed from the PyPI sdist.
- Build number reset to 0 for the new version (was 1).
- Cleanup: merged the two duplicate `extra.recipe-maintainers` keys into a single list. YAML keeps only the last key, so the previous structure was silently dropping `ianaobi`; both maintainers (`ianaobi`, `rxm7706`) are now retained.
- No upstream dependency changes: PyPI `requires_dist` still lists `pydantic>=1.10.8`, `interegular>=0.3.2`, `packaging`, `pyyaml`.

[PKG-14792]: https://anaconda.atlassian.net/browse/PKG-14792?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PKG-13217]: https://anaconda.atlassian.net/browse/PKG-13217?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ